### PR TITLE
Fix jetpack detecting `ImpNoiseListener` and exploding

### DIFF
--- a/Imperium/src/MonoBehaviours/VisualizerObjects/NoiseOverlay/ImpNoiseListener.cs
+++ b/Imperium/src/MonoBehaviours/VisualizerObjects/NoiseOverlay/ImpNoiseListener.cs
@@ -25,6 +25,8 @@ internal class ImpNoiseListener : MonoBehaviour, INoiseListener
             removeRenderer: true
         );
         noiseListenerObj.transform.position = Imperium.Player.gameplayCamera.transform.position;
+        noiseListenerObj.GetComponent<Collider>().isTrigger = true;
+
         var noiseListener = noiseListenerObj.AddComponent<ImpNoiseListener>();
 
         var canvas = Instantiate(ImpAssets.NoiseOverlay);


### PR DESCRIPTION
When flying fast, the vanilla game's jetpack flight raycast was detecting the collider of the `ImpNoiseListener`, triggering instant death. Fixed by changing the collider to a trigger which maintains functionality and prevents the jetpack from detecting it.