### PR TITLE
WeatherRegistry soft-dependency integration

### DIFF
--- a/Imperium/Imperium.csproj
+++ b/Imperium/Imperium.csproj
@@ -57,6 +57,7 @@
         <PackageReference Include="Xilophor.LethalNetworkAPI" Version="3.0.0-beta.4" />
         <PackageReference Include="Rune580.Mods.LethalCompany.InputUtils" Version="0.7.3" />
 
+        <PackageReference Include="mrov.WeatherRegistry" Version="*-*" />
         <PackageReference Include="MinVer" Version="4.*" PrivateAssets="all" Private="false" />
     </ItemGroup>
 

--- a/Imperium/src/Core/ImpConstants.cs
+++ b/Imperium/src/Core/ImpConstants.cs
@@ -54,17 +54,6 @@ public abstract class ImpConstants
         { nameof(VehicleController), "Company Cruiser" }
     };
 
-    internal static readonly string[] MoonWeathers =
-    [
-        "None",
-        "Dust Clouds",
-        "Rainy",
-        "Stormy",
-        "Foggy",
-        "Flooded",
-        "Eclipsed"
-    ];
-
     // Items that have no spawn prefab
     public static readonly HashSet<string> ItemBlacklist = ["box"];
 }

--- a/Imperium/src/Core/Lifecycle/MoonManager.cs
+++ b/Imperium/src/Core/Lifecycle/MoonManager.cs
@@ -2,6 +2,7 @@
 
 using System.Linq;
 using Imperium.API.Types.Networking;
+using Imperium.Integration;
 using Imperium.Netcode;
 using Imperium.Util;
 using Imperium.Util.Binding;
@@ -155,6 +156,10 @@ internal class MoonManager : ImpLifecycleObject
     private void OnWeatherChangeServer(ChangeWeatherRequest request, ulong clientId)
     {
         changeWeatherMessage.DispatchToClients(request);
+
+        if(WeatherRegistryIntegration.IsEnabled){
+            WeatherRegistryIntegration.ChangeWeather(Imperium.StartOfRound.levels[request.LevelIndex], request.WeatherType);
+        }
     }
 
     [ImpAttributes.LocalMethod]

--- a/Imperium/src/Integration/WeatherRegistryIntegration.cs
+++ b/Imperium/src/Integration/WeatherRegistryIntegration.cs
@@ -1,0 +1,39 @@
+#region
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using BepInEx.Bootstrap;
+using HarmonyLib;
+using Imperium.Util;
+
+#endregion
+
+namespace Imperium.Integration;
+
+public static class WeatherRegistryIntegration
+{
+    internal static bool IsEnabled => Chainloader.PluginInfos.ContainsKey("mrov.WeatherRegistry");
+
+    [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.NoOptimization)]
+    internal static List<LevelWeatherType> GetWeathers()
+    {
+        if (!IsEnabled)
+            return null;
+
+        return WeatherRegistry
+            .WeatherManager.Weathers.Select(weather => weather.VanillaWeatherType)
+            .ToList();
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.NoOptimization)]
+    internal static void ChangeWeather(SelectableLevel level, LevelWeatherType weather)
+    {
+        if (!IsEnabled)
+            return;
+
+        WeatherRegistry.WeatherController.ChangeWeather(level, weather);
+    }
+}

--- a/Imperium/src/Interface/ImperiumUI/Windows/Info/InfoWindow.cs
+++ b/Imperium/src/Interface/ImperiumUI/Windows/Info/InfoWindow.cs
@@ -159,7 +159,7 @@ internal class InfoWindow : ImperiumWindow
         scrapAmount.text = Imperium.ObjectManager.CurrentLevelItems.Value.Count(item => item.itemProperties.isScrap)
             .ToString();
         weather.text = (int)Imperium.StartOfRound.currentLevel.currentWeather >= 0
-            ? ImpConstants.MoonWeathers[(int)Imperium.StartOfRound.currentLevel.currentWeather]
+            ? Imperium.StartOfRound.currentLevel.currentWeather.ToString()
             : "Clear";
     }
 }

--- a/Imperium/src/Interface/ImperiumUI/Windows/MoonControl/Widgets/WeatherForecaster.cs
+++ b/Imperium/src/Interface/ImperiumUI/Windows/MoonControl/Widgets/WeatherForecaster.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Imperium.API.Types.Networking;
+using Imperium.Util;
 using Imperium.Types;
 using TMPro;
 using UnityEngine;
@@ -34,22 +35,22 @@ public class WeatherForecaster : ImpWidget
         }
 
         var levels = Imperium.StartOfRound.levels;
-        var options = Enum.GetValues(typeof(LevelWeatherType)).Cast<LevelWeatherType>()
-            .Select(enumValue => Enum.GetName(typeof(LevelWeatherType), enumValue))
+        var options = WeatherData.Weathers
+            .Select(enumValue => enumValue.ToString())
             .Select(weather => new TMP_Dropdown.OptionData(weather))
             .ToList();
 
         foreach (var (levelIndex, dropdown) in dropdowns)
         {
             dropdown.options = options;
-            dropdown.value = (int)levels[levelIndex].currentWeather;
+            dropdown.value = (int)(levels[levelIndex].currentWeather + 1);
 
             dropdown.onValueChanged.AddListener(_ =>
             {
                 Imperium.MoonManager.ChangeWeather(new ChangeWeatherRequest
                 {
                     LevelIndex = levelIndex,
-                    WeatherType = (LevelWeatherType)dropdown.value
+                    WeatherType = (LevelWeatherType)(dropdown.value - 1)
                 });
             });
         }

--- a/Imperium/src/Util/WeatherData.cs
+++ b/Imperium/src/Util/WeatherData.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Imperium.Integration;
+
+namespace Imperium.Util;
+
+public static class WeatherData
+{
+    public static List<LevelWeatherType> Weathers
+    {
+        get
+        {
+            if (WeatherRegistryIntegration.IsEnabled)
+            {
+                return WeatherRegistryIntegration.GetWeathers();
+            }
+
+            return Enum.GetValues(typeof(LevelWeatherType))
+                .Cast<LevelWeatherType>()
+                .OrderBy(enumValue => enumValue)
+                .ToList();
+        }
+    }
+}


### PR DESCRIPTION
This PR aims to add soft-dependency integration with [WeatherRegistry](https://thunderstore.io/c/lethal-company/p/mrov/WeatherRegistry/) (a weather controlling mod) by changing the references from vanilla's `LevelWeatherType` enum to WeatherRegistry's `WeatherManager` ones, as well as to:

- Remove Imperium's hardcoded weather names (correlated with enum values) to allow for modded weathers usage
- Create an `WeatherData` util class to allow for getting game's weather data from WeatherRegistry as well as the Enum (old/vanilla method)
- Add a reference to WeatherRegistry's `WeatherController` for changes done via Imperium's UI to be applied correctly

I've also included the dropdown value fix [you've mentioned](https://discord.com/channels/1168655651455639582/1225942840282976316/1259163045750374463) and added an enum value resolver [as per my message](https://discord.com/channels/1168655651455639582/1225942840282976316/1259171084880576553) - the `+1` fix.

Tested both with and without Registry - works without any issues.