### PR TITLE
Fix HarmonyX errors related to WeatherRegistry's soft-dependency

### DIFF
--- a/Imperium/src/Integration/WeatherRegistryIntegration.cs
+++ b/Imperium/src/Integration/WeatherRegistryIntegration.cs
@@ -1,5 +1,6 @@
 #region
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.CompilerServices;
@@ -20,8 +21,15 @@ public static class WeatherRegistryIntegration
         if (!IsEnabled)
             return null;
 
-        return WeatherManager.Weathers.Select(weather => weather.VanillaWeatherType)
-            .ToList();
+        List<Weather> weathers = WeatherRegistry.WeatherManager.Weathers;
+
+        List<LevelWeatherType> weatherTypes = [];
+        foreach (Weather weather in weathers)
+        {
+            weatherTypes.Add(weather.VanillaWeatherType);
+        }
+
+        return weatherTypes;
     }
 
     [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.NoOptimization)]
@@ -30,6 +38,6 @@ public static class WeatherRegistryIntegration
         if (!IsEnabled)
             return;
 
-        WeatherController.ChangeWeather(level, weather);
+        WeatherRegistry.WeatherController.ChangeWeather(level, weather);
     }
 }


### PR DESCRIPTION
This PR aims to fix HarmonyX errors that show up when [WeatherRegistry](https://thunderstore.io/c/lethal-company/p/mrov/WeatherRegistry/)is not present in the modpack.

```
[Warning:  HarmonyX] AccessTools.GetTypesFromAssembly: assembly giosuel.Imperium, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null => System.Reflection.ReflectionTypeLoadException: Exception of type 'System.Reflection.ReflectionTypeLoadException' was thrown.
Could not load type of field 'Imperium.Integration.WeatherRegistryIntegration+<>c:<>9__2_0' (1) due to: Could not load file or assembly 'WeatherRegistry, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null' or one of its dependencies.
  at (wrapper managed-to-native) System.Reflection.Assembly.GetTypes(System.Reflection.Assembly,bool)
  at System.Reflection.Assembly.GetTypes () [0x00000] in <787acc3c9a4c471ba7d971300105af24>:IL_0000 
  at HarmonyLib.AccessTools.GetTypesFromAssembly (System.Reflection.Assembly assembly) [0x0000d] in <474744d65d8e460fa08cd5fd82b5d65f>:IL_000D 
System.TypeLoadException: Could not load type of field 'Imperium.Integration.WeatherRegistryIntegration+<>c:<>9__2_0' (1) due to: Could not load file or assembly 'WeatherRegistry, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null' or one of its dependencies.
[Warning:  HarmonyX] AccessTools.GetTypesFromAssembly: assembly giosuel.Imperium, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null => System.Reflection.ReflectionTypeLoadException: Exception of type 'System.Reflection.ReflectionTypeLoadException' was thrown.
Could not load type of field 'Imperium.Integration.WeatherRegistryIntegration+<>c:<>9__2_0' (1) due to: Could not load file or assembly 'WeatherRegistry, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null' or one of its dependencies.
  at (wrapper managed-to-native) System.Reflection.Assembly.GetTypes(System.Reflection.Assembly,bool)
  at System.Reflection.Assembly.GetTypes () [0x00000] in <787acc3c9a4c471ba7d971300105af24>:IL_0000 
  at HarmonyLib.AccessTools.GetTypesFromAssembly (System.Reflection.Assembly assembly) [0x0000d] in <474744d65d8e460fa08cd5fd82b5d65f>:IL_000D 
System.TypeLoadException: Could not load type of field 'Imperium.Integration.WeatherRegistryIntegration+<>c:<>9__2_0' (1) due to: Could not load file or assembly 'WeatherRegistry, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null' or one of its dependencies.
[Warning:  HarmonyX] AccessTools.GetTypesFromAssembly: assembly giosuel.Imperium, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null => System.Reflection.ReflectionTypeLoadException: Exception of type 'System.Reflection.ReflectionTypeLoadException' was thrown.
Could not load type of field 'Imperium.Integration.WeatherRegistryIntegration+<>c:<>9__2_0' (1) due to: Could not load file or assembly 'WeatherRegistry, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null' or one of its dependencies.
  at (wrapper managed-to-native) System.Reflection.Assembly.GetTypes(System.Reflection.Assembly,bool)
  at System.Reflection.Assembly.GetTypes () [0x00000] in <787acc3c9a4c471ba7d971300105af24>:IL_0000 
  at HarmonyLib.AccessTools.GetTypesFromAssembly (System.Reflection.Assembly assembly) [0x0000d] in <474744d65d8e460fa08cd5fd82b5d65f>:IL_000D 
System.TypeLoadException: Could not load type of field 'Imperium.Integration.WeatherRegistryIntegration+<>c:<>9__2_0' (1) due to: Could not load file or assembly 'WeatherRegistry, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null' or one of its dependencies.
```

The error comes from `.Select` trying to access fields from missing namespace, it's fixed by doing a normal foreach loop.