### PR TITLE
Adding Trim() and fixing some issues

### DIFF
--- a/Imperium/src/Visualizers/Objects/EntityGizmo.cs
+++ b/Imperium/src/Visualizers/Objects/EntityGizmo.cs
@@ -330,7 +330,8 @@ internal class EntityGizmoConfig
             .Replace("]", "")
             .Replace("\n", "")
             .Replace("\t", "")
-            .Replace("\\", "");
+            .Replace("\\", "")
+            .Trim();
 
         Info = new ImpConfig<bool>(config, "Visualization.EntityGizmos.Info", escapedEntityName, false);
         Pathfinding = new ImpConfig<bool>(config, "Visualization.EntityGizmos.Pathfinding", escapedEntityName, false);


### PR DESCRIPTION
When experimenting with trying to fix on Imperium with a friend, we added the Trim() statement into EntityGizmo.cs, and it fixed Imperium Crashing with some mods present and allowed it to load with those mods properly.

One mod affected was my Brutal Company mod that I maintain, and although I've been setting up events and handling them the exact way as previous builds, apparently at some point it just broke with Imperium. This fix according to my friend supposedly should fix the issue with some mods causing imperium crashes.