### PR TITLE
Fix inactive tooltip log spam

### DIFF
--- a/Imperium/src/Interface/ImpTooltip.cs
+++ b/Imperium/src/Interface/ImpTooltip.cs
@@ -77,6 +77,7 @@ public class ImpTooltip : ImpWidget
 
     public void Deactivate()
     {
+        if (!gameObject.activeSelf) return;
         isActive = false;
         if (showAnimationCoroutine != null) StopCoroutine(showAnimationCoroutine);
         StartCoroutine(hideAnimation());


### PR DESCRIPTION
Fixes an issue where "Couldn't start Coroutine" is spammed in the logs.
From my tests, this fix doesn't seem to break anything