### PR TITLE
Fix up Visualizer lists for Insights and Players lists

### DIFF
--- a/Imperium/src/Interface/ImperiumUI/Windows/Visualization/Widgets/ObjectVisualizers.cs
+++ b/Imperium/src/Interface/ImperiumUI/Windows/Visualization/Widgets/ObjectVisualizers.cs
@@ -46,9 +46,11 @@ internal class ObjectVisualizers : ImpWidget
 
         insightTemplate = insightsList.Find("Item").gameObject;
         insightTemplate.SetActive(false);
+        FixupTextLabelPosition(insightTemplate);
 
         playerTemplate = playerList.Find("Item").gameObject;
         playerTemplate.SetActive(false);
+        FixupTextLabelPosition(playerTemplate);
 
         entityTemplate = entityList.Find("Item").gameObject;
         entityTemplate.SetActive(false);
@@ -183,6 +185,16 @@ internal class ObjectVisualizers : ImpWidget
         {
             configGetter(entityInfoConfig).Set(setActive);
         }
+    }
+
+    private static void FixupTextLabelPosition(GameObject item)
+    {
+        // Change Name.RectTransform.m_AnchoredPosition from -54.067223 to 100.24
+        // Fixes https://github.com/giosuel/imperium/issues/96
+        var rectTransform = item.transform.Find("Name").GetComponent<RectTransform>();
+        var position = rectTransform.anchoredPosition;
+        position.x = 100.24f;
+        rectTransform.anchoredPosition = position;
     }
 
     public void Refresh()


### PR DESCRIPTION
Adjusting anchored position to match the one from Entities list is a
proper fix but should be done in the prefabs and re-built into the
asset bundle instead of being this runtime ad-hoc C# patch.

Fixes #96