### PR TITLE
Add imperium key-value to steam lobbies for easier implementation of an ImperiumFilter mod

### DIFF
--- a/Imperium/Imperium.cs
+++ b/Imperium/Imperium.cs
@@ -333,5 +333,6 @@ public class Imperium : BaseUnityPlugin
 
         Harmony.PatchAll(typeof(PreInitPatches.PreInitSceneScriptPatch));
         Harmony.PatchAll(typeof(PreInitPatches.MenuManagerPatch));
+        Harmony.PatchAll(typeof(PreInitPatches.GameNetworkManagerPatch));
     }
 }

--- a/Imperium/Imperium.csproj
+++ b/Imperium/Imperium.csproj
@@ -83,6 +83,7 @@
         <Reference Include="Unity.RenderPipelines.HighDefinition.Runtime" HintPath="$(LethalCompanyDir)Lethal Company_Data/Managed/Unity.RenderPipelines.HighDefinition.Runtime.dll" Private="False" Publicize="true" />
         <Reference Include="Unity.RenderPipelines.Core.Runtime" HintPath="$(LethalCompanyDir)Lethal Company_Data/Managed/Unity.RenderPipelines.Core.Runtime.dll" Private="False" Publicize="true" />
         <Reference Include="Newtonsoft.Json" HintPath="$(LethalCompanyDir)Lethal Company_Data/Managed/Newtonsoft.Json.dll" Private="False" Publicize="true"/>
+        <Reference Include="Facepunch.Steamworks" HintPath="$(LethalCompanyDir)Lethal Company_Data/Managed/Facepunch.Steamworks.Win64.dll" Private="False" Publicize="true"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/Imperium/src/Patches/Systems/PreInitPatches.cs
+++ b/Imperium/src/Patches/Systems/PreInitPatches.cs
@@ -82,4 +82,12 @@ internal static class PreInitPatches
             }
         }
     }
+
+    [HarmonyPatch(typeof(GameNetworkManager))]
+    internal static class GameNetworkManagerPatch
+    {
+        [HarmonyPostfix]
+        [HarmonyPatch("SteamMatchmaking_OnLobbyCreated")]
+        private static void SteamMatchmaking_OnLobbyCreatedPatch(ref Steamworks.Data.Lobby lobby) => lobby.SetData("imperium", Imperium.PLUGIN_VERSION);
+    }
 }


### PR DESCRIPTION
While this mod is very fun to mess around with, when playing in public lobbies, it can be quite annoying to run into Imperium users.

ControlCompany implemented a measure to allow easier filtering of lobbies that use it. This is something similar for Imperium, however this doesn't mess with the lobby name, instead using the Steamworks API to help identify an Imperium lobby.

The most you can do currently is keep Imperium enabled while playing normally. This would greatly impact performance and wouldn't really solve the problem either. You should be able to tell that a lobby is using Imperium before even joining it.

This change is necessary for the implementation of such "ImperiumFilter" mod. This would not affect the use of this mod for it's intended purpose, instead allowing people to avoid trolling done with this mod.
I also believe that modifying the lobby name is not necessary, as the v80 update added a built-in way to distinguish modded lobbies from vanilla lobbies.