### PR TITLE
Fix inverted check for Speedy Shovel

### DIFF
--- a/Imperium/src/Patches/Objects/ShovelPatch.cs
+++ b/Imperium/src/Patches/Objects/ShovelPatch.cs
@@ -26,7 +26,11 @@ internal static class ShovelPatch
     [HarmonyPatch("ItemActivate")]
     internal static bool ItemActivate(Shovel __instance, bool used, bool buttonDown = true)
     {
-        if (__instance.playerHeldBy) return true;
+        if (__instance.playerHeldBy == null)
+        {
+            // Vanilla would simply `return;` anyway
+            return true;
+        }
 
         if (!Imperium.Settings.Shovel.Speedy.Value)
         {


### PR DESCRIPTION
This change fixes the feature which wasn't working entirely. However, the animation speed is not reset immediately when toggling the checkbox: it would only change on the next swing.

Fixes #62