### PR TITLE
Safeguard window layout restoration against unknown window types

### DIFF
--- a/Imperium/src/Interface/ImperiumUI/ImperiumUI.cs
+++ b/Imperium/src/Interface/ImperiumUI/ImperiumUI.cs
@@ -227,7 +227,22 @@ public class ImperiumUI : BaseUI
         var layoutConfigString = Imperium.Settings.Preferences.ImperiumWindowLayout.Value;
         if (string.IsNullOrEmpty(layoutConfigString)) return;
 
-        if (!ImpUtils.DeserializeJsonSafe<List<WindowDefinition>>(layoutConfigString, out var configList))
+        var settings = new JsonSerializerSettings
+        {
+            Error = delegate (object sender, Newtonsoft.Json.Serialization.ErrorEventArgs args)
+            {
+                if (Equals(args.ErrorContext.Member, nameof(WindowDefinition.WindowType)) &&
+                    args.ErrorContext.OriginalObject?.GetType() == typeof(WindowDefinition))
+                {
+                    // Skip unknown / removed window types.
+                    // This will deserialize into a WindowDefinition object with a null WindowType.
+                    // BUG: https://github.com/giosuel/imperium/issues/111
+                    args.ErrorContext.Handled = true;
+                }
+            }
+        };
+
+        if (!ImpUtils.DeserializeJsonSafe<List<WindowDefinition>>(layoutConfigString, settings, out var configList))
         {
             Imperium.IO.LogError("[UI] Failed to load ImperiumUI layout config. Invalid JSON detected.");
             return;
@@ -238,11 +253,12 @@ public class ImperiumUI : BaseUI
 
         foreach (var windowDefinition in configList)
         {
-            if (!windowControllers.TryGetValue(windowDefinition.WindowType, out var existingDefinition))
+            if (windowDefinition.WindowType == null || !windowControllers.TryGetValue(windowDefinition.WindowType, out var existingDefinition))
             {
                 // Ignore non-registered window types
                 // BUG: https://github.com/giosuel/imperium/issues/111
-                Imperium.IO.LogInfo($"[UI] Ignoring unknown window definition of type {windowDefinition.WindowType}");
+                var debugType = windowDefinition.WindowType?.ToString() ?? "[REDACTED]";
+                Imperium.IO.LogInfo($"[UI] Ignoring unknown window definition of type {debugType}");
                 continue;
             }
             if (!controllers.Add(existingDefinition.WindowType)) continue;

--- a/Imperium/src/Util/ImpUtils.cs
+++ b/Imperium/src/Util/ImpUtils.cs
@@ -178,11 +178,11 @@ public abstract class ImpUtils
     /// <param name="deserializedObj"></param>
     /// <typeparam name="T"></typeparam>
     /// <returns></returns>
-    public static bool DeserializeJsonSafe<T>(string jsonString, out T deserializedObj)
+    public static bool DeserializeJsonSafe<T>(string jsonString, JsonSerializerSettings settings, out T deserializedObj)
     {
         try
         {
-            deserializedObj = JsonConvert.DeserializeObject<T>(jsonString);
+            deserializedObj = JsonConvert.DeserializeObject<T>(jsonString, settings);
             return deserializedObj != null;
         }
         catch (Exception)


### PR DESCRIPTION
This patch set addresses the breakage in Imperium v1.2.0+ known as "Imperium launch failed. Shutting down." due to the recent removal of the Save File Editor.

The first patch hot-fixes the issue, while the second one makes it future-proof.

### Safeguard window layout restoration against unknown window types

Partially fixes window layout restoration algorithm broken by the recent
removal of Save File Editor from the registered window types.

The class itself still exists in the DLL, but it is removed, it would
break config deserialization again, although this time it would only
print an error and fallback to the default layout.

### Safeguard window layout restoration against unknown .NET types

This is a comprehensive fix for safe deserialization of window layout
definitions in case their types were removed from Imperium DLL in the
future updates.

With this change loading a new Imperium with a config from v1.1.1
results only in harmless log messages and otherwise functional layout
restoration:

```
[Info   :  Imperium] [UI] Ignoring unknown window definition of type [REDACTED]
[Info   :  Imperium] [UI] Ignoring unknown window definition of type Imperium.Interface.ImperiumUI.Windows.SaveEditor.SaveEditorWindow
```

Unknown and unparsable window types will be skipped during load,
so they won't appear in the config anymore after next save.

---

Fixes #111