### PR TITLE
Remove generated plugin info

### DIFF
--- a/Imperium/Imperium.csproj
+++ b/Imperium/Imperium.csproj
@@ -37,12 +37,7 @@
     <ItemGroup>
         <PackageReference Include="BepInEx.Analyzers" Version="1.*" PrivateAssets="all"/>
         <PackageReference Include="BepInEx.Core" Version="5.*"/>
-        <PackageReference Include="BepInEx.PluginInfoProps" Version="1.*"/>
         <PackageReference Include="BepInEx.AssemblyPublicizer.MSBuild" Version="0.4.1" PrivateAssets="all" ExcludeAssets="runtime"/>
-        <PackageReference Include="BepInEx.AutoPlugin" Version="1.1.0">
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-            <PrivateAssets>all</PrivateAssets>
-        </PackageReference>
 
         <PackageReference Include="LethalCompany.GameLibs.Steam" Version="81.0.0-*" Publicize="true" PrivateAssets="all" Private="false"/>
         <PackageReference Include="UnityEngine.Modules" Version="2022.3.62" IncludeAssets="compile"/>
@@ -85,36 +80,6 @@
         <PropertyGroup>
             <PlainVersion>$(MinVerMajor).$(MinVerMinor).$(MinVerPatch)</PlainVersion>
         </PropertyGroup>
-    </Target>
-
-    <Target
-            Name="AddGeneratedFile"
-            BeforeTargets="BeforeBuild;CoreCompile"
-            DependsOnTargets="SetPluginVersion"
-            Inputs="$(MSBuildAllProjects)"
-            Outputs="$(IntermediateOutputPath)GeneratedFile.cs">
-        <PropertyGroup>
-            <BepInExPluginGuid Condition="'$(BepInExPluginGuid)' == ''">$(AssemblyName)</BepInExPluginGuid>
-            <BepInExPluginName Condition="'$(BepInExPluginName)' == ''">$(Product)</BepInExPluginName>
-            <BepInExPluginVersion Condition="'$(BepInExPluginVersion)' == ''">$(PlainVersion)</BepInExPluginVersion>
-            <GeneratedText><![CDATA[
-namespace $(RootNamespace)
-{
-    internal static class LCMPluginInfo
-    {
-        public const string PLUGIN_GUID = "$(BepInExPluginGuid)"%3B
-        public const string PLUGIN_NAME = "$(BepInExPluginName)"%3B
-        public const string PLUGIN_VERSION = "$(BepInExPluginVersion)"%3B
-    }
-}
-      ]]></GeneratedText>
-            <GeneratedFilePath>$(IntermediateOutputPath)LCMPluginInfo.cs</GeneratedFilePath>
-        </PropertyGroup>
-        <ItemGroup>
-            <Compile Include="$(GeneratedFilePath)" />
-            <FileWrites Include="$(GeneratedFilePath)" />
-        </ItemGroup>
-        <WriteLinesToFile Lines="$(GeneratedText)" File="$(GeneratedFilePath)" WriteOnlyWhenDifferent="true" Overwrite="true" />
     </Target>
 
     <!-- Call with `dotnet build -target:PackThunderstore` -->


### PR DESCRIPTION
Neither of the two are used in the project, as Imperium sets plugin
info from its own hardcoded static constant strings.