### PR TITLE
Theme: Add transparency to the new theme Shade

### DIFF
--- a/Imperium/src/Types/ImpTheme.cs
+++ b/Imperium/src/Types/ImpTheme.cs
@@ -168,7 +168,7 @@ public static class ImpThemeManager
         {
             "Shade", new ImpTheme
             {
-                backgroundColor = HEXToRGB("#111621"),
+                backgroundColor = HEXToRGB("#111621FB"),
                 primaryColor = HEXToRGB("#464e6b"),
                 textColor = HEXToRGB("#FFFFFF")
             }


### PR DESCRIPTION
In-line with the rest of the built-in themes here, add a slight amount
of transparency to the background color.

Amends 652080a55ba1dadebefa881fce1e3aff88b87364