### PR TITLE
Speedy Shovel: Reset player animation speed right after hit animation

### DIFF
--- a/Imperium/src/Patches/Objects/ShovelPatch.cs
+++ b/Imperium/src/Patches/Objects/ShovelPatch.cs
@@ -1,6 +1,7 @@
 #region
 
 using System.Collections;
+using GameNetcodeStuff;
 using HarmonyLib;
 using Imperium.Util;
 using UnityEngine;
@@ -12,9 +13,6 @@ namespace Imperium.Patches.Objects;
 [HarmonyPatch(typeof(Shovel))]
 internal static class ShovelPatch
 {
-    private static readonly int ShovelHit = Animator.StringToHash("shovelHit");
-    private static readonly int ReelingUp = Animator.StringToHash("reelingUp");
-
     [HarmonyPostfix]
     [HarmonyPatch("DiscardItem")]
     internal static void DiscardItemPatch(Shovel __instance)
@@ -22,44 +20,116 @@ internal static class ShovelPatch
         Imperium.Visualization.ShovelGizmos.Refresh(__instance, false);
     }
 
-    [HarmonyPrefix]
-    [HarmonyPatch("ItemActivate")]
-    internal static bool ItemActivate(Shovel __instance, bool used, bool buttonDown = true)
-    {
-        if (__instance.playerHeldBy == null)
-        {
-            // Vanilla would simply `return;` anyway
-            return true;
-        }
-
-        if (!Imperium.Settings.Shovel.Speedy.Value)
-        {
-            __instance.playerHeldBy.playerBodyAnimator.speed = 1;
-            return true;
-        }
-
-        __instance.isHoldingButton = buttonDown;
-        if (!__instance.reelingUp && buttonDown)
-        {
-            __instance.playerHeldBy.playerBodyAnimator.speed = 3;
-            __instance.reelingUp = true;
-
-            __instance.previousPlayerHeldBy = __instance.playerHeldBy;
-
-            if (__instance.reelingUpCoroutine != null) __instance.StopCoroutine(__instance.reelingUpCoroutine);
-            __instance.reelingUpCoroutine = __instance.StartCoroutine(__instance.reelUpShovel());
-        }
-
-        return false;
-    }
-
     /// <summary>
-    ///     Run original enumerator <see cref="Shovel.reelUpShovel" /> but remove static waiting times.
+    ///     Run original enumerator but remove static waiting times and setup/reset speed.
     /// </summary>
     [HarmonyPostfix]
     [HarmonyPatch("reelUpShovel")]
-    private static IEnumerator reelUpShovelPatch(IEnumerator __result)
+    internal static IEnumerator reelUpShovelPostfixPatch(IEnumerator __result, Shovel __instance)
     {
-        return ImpUtils.SkipWaitingForSeconds(__result);
+        if (Imperium.Settings.Shovel.Speedy.Value)
+        {
+            return SpeedyShovelPlayerBehaviour.reelUpShovel(__result, __instance);
+        }
+        else
+        {
+            // just run vanilla
+            return __result;
+        }
+    }
+}
+
+internal class SpeedyShovelPlayerBehaviour : MonoBehaviour
+{
+    private int LayerIndex;
+
+    private Animator PlayerBodyAnimator;
+
+    private Coroutine Coroutine;
+
+    private const float SPEED_DEFAULT = 1f;
+    private const float SPEED_SPEEDY = 3f;
+
+    /// <summary>
+    ///     Replacement or rather wrapper for vanilla <see cref="Shovel.reelUpShovel" /> coroutine,
+    ///     but remove static waiting times and setup/reset speed. Assumes that Speedy Shovel setting
+    ///     is enabled at the call time.
+    /// </summary>
+    internal static IEnumerator reelUpShovel(IEnumerator source, Shovel shovel)
+    {
+        var self = ImpUtils.GetOrAddComponent<SpeedyShovelPlayerBehaviour>(shovel.playerHeldBy);
+        self.ReelUp();
+
+        var wrapper = ImpUtils.SkipWaitingForSeconds(source);
+        while (wrapper.MoveNext())
+        {
+            yield return wrapper.Current;
+        }
+        // reelingUpCoroutine has been reset to null at the end of vanilla method,
+        // so StopCoroutine won't be called for whatever comes next. Hence this custom
+        // MonoBehaviour with our own coroutine management.
+        self.ResetSpeedAfterAnimation();
+    }
+
+    private void Awake()
+    {
+        PlayerBodyAnimator = gameObject.GetComponent<PlayerControllerB>().playerBodyAnimator;
+        LayerIndex = PlayerBodyAnimator.GetLayerIndex(ImpAnimator.Metarig.Layer_HoldingItemsBothHands);
+    }
+
+    private void ReelUp()
+    {
+        StopResetCoroutine();
+        if (Imperium.Settings.Shovel.Speedy.Value)
+        {
+            SpeedUp();
+        }
+        else
+        {
+            ResetSpeed();
+        }
+    }
+
+    private void ResetSpeedAfterAnimation()
+    {
+        StopResetCoroutine();
+        Coroutine = StartCoroutine(ResetSpeedAfterAnimationCoroutine());
+    }
+
+    private void StopResetCoroutine()
+    {
+        if (Coroutine != null)
+        {
+            StopCoroutine(Coroutine);
+        }
+    }
+
+    private IEnumerator ResetSpeedAfterAnimationCoroutine()
+    {
+        // Wait until the (sped up) animation is completed before resetting the speed
+        yield return new WaitUntil(() =>
+        {
+            AnimatorStateInfo stateInfo = PlayerBodyAnimator.GetCurrentAnimatorStateInfo(LayerIndex);
+            var hash = stateInfo.shortNameHash;
+            return hash != ImpAnimator.Metarig.ShovelReelUp
+                && hash != ImpAnimator.Metarig.HitShovel;
+        });
+        ResetSpeed();
+        Coroutine = null;
+    }
+
+    private void SpeedUp()
+    {
+        SetSpeed(SPEED_SPEEDY);
+    }
+
+    private void ResetSpeed()
+    {
+        SetSpeed(SPEED_DEFAULT);
+    }
+
+    private void SetSpeed(float speed)
+    {
+        PlayerBodyAnimator.speed = speed;
     }
 }

--- a/Imperium/src/Util/AnimatorHash.cs
+++ b/Imperium/src/Util/AnimatorHash.cs
@@ -1,0 +1,20 @@
+#region
+
+using UnityEngine;
+
+#endregion
+
+namespace Imperium.Util;
+
+/// <summary>
+///     Layers or animators and hashes of animations names.
+/// </summary>
+internal static class ImpAnimator
+{
+    internal static class Metarig
+    {
+        internal const string Layer_HoldingItemsBothHands = "HoldingItemsBothHands";
+        internal static readonly int ShovelReelUp = Animator.StringToHash("ShovelReelUp");
+        internal static readonly int HitShovel = Animator.StringToHash("HitShovel");
+    }
+}

--- a/Imperium/src/Util/ImpUtils.cs
+++ b/Imperium/src/Util/ImpUtils.cs
@@ -343,4 +343,18 @@ public abstract class ImpUtils
             yield return it;
         }
     }
+
+    internal static T GetOrAddComponent<T>(MonoBehaviour self) where T : MonoBehaviour
+    {
+        return GetOrAddComponent<T>(self.gameObject);
+    }
+
+    internal static T GetOrAddComponent<T>(GameObject self) where T : MonoBehaviour
+    {
+        if (!self.TryGetComponent<T>(out var component))
+        {
+            component = self.AddComponent<T>();
+        }
+        return component;
+    }
 }


### PR DESCRIPTION
Speeding up an animation consists of three parts:
- increasing animation speed,
- skipping any yield WaitForSeconds objects,
- and resetting animation speed.

But the animation still has to run for some time, hence its speed can't
be reset straight away, and an AnimatorStateInfo trick is required to
wait as little as possible before safely resetting.

The vanilla coroutine is assigned to a member variable that it passes to
StopCoroutine before starting a new one. However, the coroutine itself
resets the member variable to null at the end of its body, making the
coroutine unstoppable after the vanilla coroutine completes. That's why
after running through the vanilla enumerator, we start our own managed
coroutine to reset the animation.

Closes #151