### PR TITLE
Night Vision: Make it work everywhere, reparent to active camera

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Made it so challenge moon scores won't be submitted with Imperium enabled.
 - Added the possibility to change the custom welcome message.
 - Night Vision now works outdoors and in orbit too.
+- Night Vision now follows active camera in Spectate, Freecam and any other mode.
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Added visualizers for the new LOS functions.
 - Made it so challenge moon scores won't be submitted with Imperium enabled.
 - Added the possibility to change the custom welcome message.
+- Night Vision now works outdoors and in orbit too.
 
 ### Bug Fixes
 

--- a/Imperium/src/Core/Scripts/ImpNightVision.cs
+++ b/Imperium/src/Core/Scripts/ImpNightVision.cs
@@ -76,9 +76,9 @@ public class ImpNightVision : MonoBehaviour
     {
         var active = nightVision > 0f;
 
-        // disabling HDAdditionalLightData won't do anything useful
-        Near.Light.enabled = active;
-        Far.Light.enabled = active;
+        // Disabling HDAdditionalLightData on its own won't do anything useful, the Light needs to be disabled.
+        // While at it, disable the whole GameObject to avoid reparenting to cameras while inactive.
+        gameObject.SetActive(active);
 
         if (active)
         {

--- a/Imperium/src/Core/Scripts/ImpNightVision.cs
+++ b/Imperium/src/Core/Scripts/ImpNightVision.cs
@@ -1,6 +1,7 @@
 #region
 
 using UnityEngine;
+using UnityEngine.Rendering.HighDefinition;
 
 #endregion
 
@@ -8,34 +9,50 @@ namespace Imperium.Core.Scripts;
 
 public class ImpNightVision : MonoBehaviour
 {
-    private Light FarLight;
-    private Light NearLight;
+    private ImpNightVisionLight Near;
+    private ImpNightVisionLight Far;
 
     internal static ImpNightVision Create() => new GameObject("Imp_NightVision").AddComponent<ImpNightVision>();
 
     private void Awake()
     {
         var mapCamera = GameObject.Find("MapCamera").transform;
+        var position = mapCamera.position;
         transform.SetParent(Imperium.Player.gameplayCamera.transform);
 
-        NearLight = new GameObject("Near").AddComponent<Light>();
-        NearLight.transform.SetParent(transform);
-        NearLight.transform.position = mapCamera.position + Vector3.down * 80f;
-        NearLight.range = 70f;
-        NearLight.color = new Color(0.875f, 0.788f, 0.791f, 1);
+        Near = SetupLight("Near", transform);
+        Near.GameObject.transform.position = position + Vector3.down * 80f;
+        Near.Light.range = 70f;
+        Near.Light.color = new Color(0.875f, 0.788f, 0.791f, 1);
 
-        FarLight = new GameObject("Far").AddComponent<Light>();
-        FarLight.transform.SetParent(transform);
-        FarLight.transform.position = mapCamera.position + Vector3.down * 30f;
-        FarLight.range = 500f;
+        Far = SetupLight("Far", transform);
+        Far.GameObject.transform.position = position + Vector3.down * 30f;
+        Far.Light.range = 500f;
+    }
+
+    private static ImpNightVisionLight SetupLight(string gameObjectName, Transform parent)
+    {
+        var obj = new GameObject(gameObjectName);
+        obj.transform.SetParent(parent);
+        return new()
+        {
+            GameObject = obj,
+            Light = obj.AddComponent<Light>(),
+        };
     }
 
     private void Update()
     {
-        FarLight.enabled = Imperium.Player.nightVision.enabled;
-        NearLight.enabled = Imperium.Player.nightVision.enabled;
+        Near.Light.enabled = Imperium.Player.nightVision.enabled;
+        Far.Light.enabled = Imperium.Player.nightVision.enabled;
 
-        NearLight.intensity = Imperium.Settings.Player.NightVision.Value * 100f;
-        FarLight.intensity = Imperium.Settings.Player.NightVision.Value * 1100f;
+        Near.Light.intensity = Imperium.Settings.Player.NightVision.Value * 100f;
+        Far.Light.intensity = Imperium.Settings.Player.NightVision.Value * 1100f;
     }
+}
+
+internal record ImpNightVisionLight
+{
+    internal GameObject GameObject { get; init; }
+    internal Light Light { get; init; }
 }

--- a/Imperium/src/Core/Scripts/ImpNightVision.cs
+++ b/Imperium/src/Core/Scripts/ImpNightVision.cs
@@ -1,5 +1,6 @@
 #region
 
+using GameNetcodeStuff;
 using UnityEngine;
 using UnityEngine.Rendering.HighDefinition;
 
@@ -18,7 +19,7 @@ public class ImpNightVision : MonoBehaviour
     {
         var mapCamera = GameObject.Find("MapCamera").transform;
         var position = mapCamera.position;
-        transform.SetParent(Imperium.Player.gameplayCamera.transform);
+        ReparentToActiveCamera();
 
         Near = SetupLight("Near", transform);
         Near.GameObject.transform.position = position + Vector3.down * 80f;
@@ -40,6 +41,27 @@ public class ImpNightVision : MonoBehaviour
             Light = obj.AddComponent<Light>(),
             Data = obj.AddComponent<HDAdditionalLightData>(),
         };
+    }
+
+	public void OnEnable()
+	{
+        ReparentToActiveCamera();
+		Imperium.StartOfRound.CameraSwitchEvent.AddListener(OnCameraSwitch);
+	}
+
+	public void OnDisable()
+	{
+		Imperium.StartOfRound.CameraSwitchEvent.RemoveListener(OnCameraSwitch);
+	}
+
+    private void OnCameraSwitch()
+    {
+        ReparentToActiveCamera();
+    }
+
+    private void ReparentToActiveCamera()
+    {
+        transform.SetParent(Imperium.StartOfRound.activeCamera.transform, worldPositionStays: false);
     }
 
     private void Update()

--- a/Imperium/src/Core/Scripts/ImpNightVision.cs
+++ b/Imperium/src/Core/Scripts/ImpNightVision.cs
@@ -29,6 +29,14 @@ public class ImpNightVision : MonoBehaviour
         Far = SetupLight("Far", transform);
         Far.GameObject.transform.position = position + Vector3.down * 30f;
         Far.Data.range = 500f;
+
+        Imperium.Settings.Player.NightVision.onUpdate += Refresh;
+        Refresh(Imperium.Settings.Player.NightVision.Value);
+    }
+
+    private void OnDestroy()
+    {
+        Imperium.Settings.Player.NightVision.onUpdate -= Refresh;
     }
 
     private static ImpNightVisionLight SetupLight(string gameObjectName, Transform parent)
@@ -64,9 +72,8 @@ public class ImpNightVision : MonoBehaviour
         transform.SetParent(Imperium.StartOfRound.activeCamera.transform, worldPositionStays: false);
     }
 
-    private void Update()
+    private void Refresh(float nightVision)
     {
-        var nightVision = Imperium.Settings.Player.NightVision.Value;
         var active = nightVision > 0f;
 
         // disabling HDAdditionalLightData won't do anything useful

--- a/Imperium/src/Core/Scripts/ImpNightVision.cs
+++ b/Imperium/src/Core/Scripts/ImpNightVision.cs
@@ -22,12 +22,12 @@ public class ImpNightVision : MonoBehaviour
 
         Near = SetupLight("Near", transform);
         Near.GameObject.transform.position = position + Vector3.down * 80f;
-        Near.Light.range = 70f;
-        Near.Light.color = new Color(0.875f, 0.788f, 0.791f, 1);
+        Near.Data.range = 70f;
+        Near.Data.color = new Color(0.875f, 0.788f, 0.791f, 1);
 
         Far = SetupLight("Far", transform);
         Far.GameObject.transform.position = position + Vector3.down * 30f;
-        Far.Light.range = 500f;
+        Far.Data.range = 500f;
     }
 
     private static ImpNightVisionLight SetupLight(string gameObjectName, Transform parent)
@@ -38,16 +38,19 @@ public class ImpNightVision : MonoBehaviour
         {
             GameObject = obj,
             Light = obj.AddComponent<Light>(),
+            Data = obj.AddComponent<HDAdditionalLightData>(),
         };
     }
 
     private void Update()
     {
+        // disabling HDAdditionalLightData won't do anything useful
         Near.Light.enabled = Imperium.Player.nightVision.enabled;
         Far.Light.enabled = Imperium.Player.nightVision.enabled;
 
-        Near.Light.intensity = Imperium.Settings.Player.NightVision.Value * 100f;
-        Far.Light.intensity = Imperium.Settings.Player.NightVision.Value * 1100f;
+        // intensity must be set on HDAdditionalLightData as the source of truth
+        Near.Data.intensity = Imperium.Settings.Player.NightVision.Value * 100f * 4f * Mathf.PI;
+        Far.Data.intensity = Imperium.Settings.Player.NightVision.Value * 1100f * 4f * Mathf.PI;
     }
 }
 
@@ -55,4 +58,5 @@ internal record ImpNightVisionLight
 {
     internal GameObject GameObject { get; init; }
     internal Light Light { get; init; }
+    internal HDAdditionalLightData Data { get; init; }
 }

--- a/Imperium/src/Core/Scripts/ImpNightVision.cs
+++ b/Imperium/src/Core/Scripts/ImpNightVision.cs
@@ -44,13 +44,19 @@ public class ImpNightVision : MonoBehaviour
 
     private void Update()
     {
-        // disabling HDAdditionalLightData won't do anything useful
-        Near.Light.enabled = Imperium.Player.nightVision.enabled;
-        Far.Light.enabled = Imperium.Player.nightVision.enabled;
+        var nightVision = Imperium.Settings.Player.NightVision.Value;
+        var active = nightVision > 0f;
 
-        // intensity must be set on HDAdditionalLightData as the source of truth
-        Near.Data.intensity = Imperium.Settings.Player.NightVision.Value * 100f * 4f * Mathf.PI;
-        Far.Data.intensity = Imperium.Settings.Player.NightVision.Value * 1100f * 4f * Mathf.PI;
+        // disabling HDAdditionalLightData won't do anything useful
+        Near.Light.enabled = active;
+        Far.Light.enabled = active;
+
+        if (active)
+        {
+            // intensity must be set on HDAdditionalLightData as the source of truth
+            Near.Data.intensity = nightVision * 100f * 4f * Mathf.PI;
+            Far.Data.intensity = nightVision * 1100f * 4f * Mathf.PI;
+        }
     }
 }
 


### PR DESCRIPTION
### Night Vision: refactor to store objects and components in a struct

For the sake of bookkeeping let's store all relevant objects in an
ad-hoc record structure instead of half a dozen flat members. This will
become more impactful with a new upcoming component.

Also sort the two lights consistently: Near, then Far.


### Night Vision: refactor to set intensity on HDAdditionalLightData

In HDRP graphics modifying Light.intensity directly is wrong, and will
be overridden (reset) by HDAdditionalLightData once Unity engine
automatically adds one for each Light anyway.

This was not a noticeable bug, because HD light only overrides Light
property in setter and during initialization, but we override it every
frame during Update. However, with an upcoming patch to remove Update
hook, it will become relevant, as in my testing the Light intensity
would be reset at start until the player moves the slider control.

Also, HDAdditionalLightData.intensity uses a different formula than
Light.intensity, which for the default lightUnit = Lumen would be a
factor of `1 / (4 * π)`, i.e.

    1 Light.intensity == 4 * π * HDAdditionalLightData.intensity


### Night Vision: Make it work outdoor

Allow Imperium's Night Vision to work outdoors and in orbit by
decoupling its state from vanilla PlayerControllerB.nightVision state.

Vanilla only enables night vision for local or spectated client who is
also inside facility (`isInsideFactory`), which limited usefulness of
Imperium feature at late hours outdoor.

Fixes #53


### Night Vision: Always follow the active camera

Makes it work in Spectate mode, Freecam mode -- everywhere all the time.


### Night Vision: Port Update to reactive event handler

Instead of running the code every frame for values which don't change
often, subscribe to their updates.

This optimization was made possible by removing an unobservable
Imperium.Player.nightVision.enabled from the equation earlier.


### Night Vision: Disable completely when unused

This is a tiny optimization that avoid processing camera switch events
when the whole Night Vision feature is disabled (slider value set to 0).

