### PR TITLE
Teleportation: Use EntranceTeleport component to find Fire Exits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Renamed the 'Breeze' theme to 'Repo'.
 - Moved the "Disable Le Funni" config to the hidden category.
 - Adjusted most of the themes slightly to make them more consistent.
+- Adjusted Fire Exit teleportation to not teleport out of bounds.
 
 ## Imperium v1.3.0 - Regular Update
 

--- a/Imperium/src/Interface/ImperiumUI/Windows/Teleport/Widgets/Teleportation.cs
+++ b/Imperium/src/Interface/ImperiumUI/Windows/Teleport/Widgets/Teleportation.cs
@@ -165,13 +165,14 @@ public class Teleportation : ImpWidget
         foreach (var obj in objs)
         {
             if (obj.name != "FireExitDoor" || obj.transform.position.y > -100) continue;
+            var entrancePointPosition = obj.transform.position;
 
             var newFireExit = Instantiate(fireExitTemplate, fireExitContainer);
             var newFireExitText = newFireExit.transform.Find("Text").GetComponent<TMP_Text>();
             newFireExitText.text = $"Exit #{fireExitCounter + 1}";
 
             var newFireExitButton = newFireExit.transform.GetComponent<Button>();
-            newFireExitButton.onClick.AddListener(() => TeleportTo(obj.transform.position));
+            newFireExitButton.onClick.AddListener(() => TeleportTo(entrancePointPosition));
             ImpThemeManager.Style(
                 theme.Value,
                 newFireExitButton.transform,

--- a/Imperium/src/Interface/ImperiumUI/Windows/Teleport/Widgets/Teleportation.cs
+++ b/Imperium/src/Interface/ImperiumUI/Windows/Teleport/Widgets/Teleportation.cs
@@ -156,16 +156,24 @@ public class Teleportation : ImpWidget
 
     private void SetFireExits()
     {
-        var objs = FindObjectsOfType<GameObject>();
-        var fireExitCounter = 0;
-
         foreach (var fireExit in fireExits) Destroy(fireExit.gameObject);
         fireExits.Clear();
 
-        foreach (var obj in objs)
+        // Exclude inactive teleports like the ones on Gordion
+        var entranceTeleports = FindObjectsByType<EntranceTeleport>(FindObjectsInactive.Exclude, FindObjectsSortMode.None);
+        var fireExitCounter = 0;
+
+        // Outdoors teleports have isEntranceToBuilding set to true, indoors set to false.
+        // Teleports are wired up in pairs by incremental entranceId. Main ID is zero.
+
+        foreach (var entranceTeleport in entranceTeleports)
         {
-            if (obj.name != "FireExitDoor" || obj.transform.position.y > -100) continue;
-            var entrancePointPosition = obj.transform.position;
+            if (entranceTeleport.isEntranceToBuilding || entranceTeleport.entranceId == 0)
+            {
+                continue;
+            }
+            var entrancePoint = entranceTeleport.entrancePoint;
+            var entrancePointPosition = entrancePoint.position;
 
             var newFireExit = Instantiate(fireExitTemplate, fireExitContainer);
             var newFireExitText = newFireExit.transform.Find("Text").GetComponent<TMP_Text>();


### PR DESCRIPTION
Instead of searching for objects by name, use native vanilla types and
properties. This also guarantees to teleport players in bounds.

Replaces #170