### PR TITLE
Teleportation: Use EntranceTeleport to find Main Entrance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Renamed the 'Breeze' theme to 'Repo'.
 - Moved the "Disable Le Funni" config to the hidden category.
 - Adjusted most of the themes slightly to make them more consistent.
+- Adjusted search algorithm for Main Entrance to rely on entrance ID rather than on naming convention, improving compatibility with modded moons.
 
 ## Imperium v1.3.0 - Regular Update
 

--- a/Imperium/src/Core/Lifecycle/PlayerManager.cs
+++ b/Imperium/src/Core/Lifecycle/PlayerManager.cs
@@ -83,8 +83,17 @@ internal class PlayerManager : ImpLifecycleObject
         );
 
         MainEntranceTPAnchor = new ImpExternalBinding<Vector3?, bool>(() =>
-            GameObject.Find("EntranceTeleportA")?.transform.position
-        );
+        {
+            var entranceTeleports = FindObjectsByType<EntranceTeleport>(
+                FindObjectsInactive.Exclude, FindObjectsSortMode.None
+            );
+            // Outdoors teleports have isEntranceToBuilding set to true, indoors set to false.
+            // Teleports are wired up in pairs by incremental entranceId. Main ID is zero.
+            var entranceTeleport = entranceTeleports.FirstOrDefault(
+                tp => tp.isEntranceToBuilding && tp.entranceId == 0
+            );
+            return entranceTeleport?.entrancePoint.position;
+        });
 
         ApparatusTPAnchor = new ImpExternalBinding<Vector3?, bool>(() =>
         {


### PR DESCRIPTION
Instead of relying on object naming convention, use native vanilla types
and properties. This should improve compatibility with modded moons.

(I personally don't know which though)